### PR TITLE
Support resolver parameters

### DIFF
--- a/src/__tests__/query.ts
+++ b/src/__tests__/query.ts
@@ -71,9 +71,9 @@ describe('query', () => {
   const key1: Key = 'key1';
 
   type KeyResult = string;
-  type KeyQuery = true;
+  type KeyQuery = string;
   const key1Result: KeyResult = 'result1';
-  const key1Query: KeyQuery = true;
+  const key1Query: KeyQuery = 'query1';
   const processKey: CustomQP<KeyQuery, KeyResult, [Key, Id]> = scrapql.process.query.leaf(
     (r) => r.fetchKeyResult,
   );
@@ -83,7 +83,9 @@ describe('query', () => {
     const main = processKey(resolvers)([key1, id1])(key1Query);
     const result = await main();
     expect((resolvers.checkProperty1Existence as any).mock.calls).toMatchObject([]);
-    expect((resolvers.fetchKeyResult as any).mock.calls).toMatchObject([[id1, key1]]);
+    expect((resolvers.fetchKeyResult as any).mock.calls).toMatchObject([
+      [id1, key1, key1Query],
+    ]);
     expect((resolvers.fetchProperty2Result as any).mock.calls).toMatchObject([]);
     expect(result).toEqual(key1Result);
   });
@@ -105,7 +107,9 @@ describe('query', () => {
     const main = processKeys(resolvers)([id1])(keysQuery);
     const result = await main();
     expect((resolvers.checkProperty1Existence as any).mock.calls).toMatchObject([]);
-    expect((resolvers.fetchKeyResult as any).mock.calls).toMatchObject([[id1, key1]]);
+    expect((resolvers.fetchKeyResult as any).mock.calls).toMatchObject([
+      [id1, key1, key1Query],
+    ]);
     expect((resolvers.fetchProperty2Result as any).mock.calls).toMatchObject([]);
     expect(result).toEqual(keysResult);
   });
@@ -135,15 +139,17 @@ describe('query', () => {
       [id1],
       [id2],
     ]);
-    expect((resolvers.fetchKeyResult as any).mock.calls).toMatchObject([[id1, key1]]);
+    expect((resolvers.fetchKeyResult as any).mock.calls).toMatchObject([
+      [id1, key1, key1Query],
+    ]);
     expect((resolvers.fetchProperty2Result as any).mock.calls).toMatchObject([]);
     expect(result).toEqual(property1Result);
   });
 
   type Property2Result = string;
-  type Property2Query = true;
+  type Property2Query = string;
   const property2Result: Property2Result = 'result2';
-  const property2Query: Property2Query = true;
+  const property2Query: Property2Query = 'query2';
   const processProperty2: CustomQP<
     Property2Query,
     Property2Result,
@@ -156,7 +162,9 @@ describe('query', () => {
     const result = await main();
     expect((resolvers.checkProperty1Existence as any).mock.calls).toMatchObject([]);
     expect((resolvers.fetchKeyResult as any).mock.calls).toMatchObject([]);
-    expect((resolvers.fetchProperty2Result as any).mock.calls).toMatchObject([[]]);
+    expect((resolvers.fetchProperty2Result as any).mock.calls).toMatchObject([
+      [property2Query],
+    ]);
     expect(result).toEqual(property2Result);
   });
 
@@ -199,7 +207,9 @@ describe('query', () => {
       [id1],
       [id2],
     ]);
-    expect((resolvers.fetchKeyResult as any).mock.calls).toMatchObject([[id1, key1]]);
+    expect((resolvers.fetchKeyResult as any).mock.calls).toMatchObject([
+      [id1, key1, key1Query],
+    ]);
     expect((resolvers.fetchProperty2Result as any).mock.calls).toMatchObject([]);
     expect(result).toEqual(rootResult);
   });
@@ -229,7 +239,9 @@ describe('query', () => {
       [id1],
       [id2],
     ]);
-    expect((resolvers.fetchKeyResult as any).mock.calls).toMatchObject([[id1, key1]]);
+    expect((resolvers.fetchKeyResult as any).mock.calls).toMatchObject([
+      [id1, key1, key1Query],
+    ]);
     expect((resolvers.fetchProperty2Result as any).mock.calls).toMatchObject([]);
     expect(result).toEqual(rootResult);
   });

--- a/src/result.ts
+++ b/src/result.ts
@@ -63,7 +63,9 @@ export function leaf<A extends Reporters, R extends LeafResult, C extends Contex
   connect: ReporterConnector<A, R, C>,
 ): ResultProcessor<R, A, C> {
   return (reporters: A) => (context: C) => (result: R) => {
-    return connect(reporters)(...reporterArgsFrom(context, result));
+    const reporter = connect(reporters);
+    const args = reporterArgsFrom(context, result);
+    return reporter(...args);
   };
 }
 

--- a/src/scrapql.ts
+++ b/src/scrapql.ts
@@ -13,16 +13,21 @@ export type Key = string;
 export type Property = string;
 export type Err = Json;
 
-export type ExistenceQuery = never; // the query is implicit
+export type ExistenceQuery<Q extends string> = Q & {
+  readonly ExistenceQuery: unique symbol;
+};
+export const existenceQuery = <I extends Id>(id: I): ExistenceQuery<I> =>
+  id as ExistenceQuery<I>;
+
 export type LiteralQuery = Json;
-export type LeafQuery = true;
+export type LeafQuery = Json;
 export type KeysQuery<S extends Query = Json> = Record<Key, S>;
 export type IdsQuery<S extends Query = Json> = Record<Id, S>;
 export type PropertiesQuery<
   Q extends { [I in Property]: Query } = { [I in Property]: Json }
 > = Partial<Q>;
 
-export type FetchableQuery = LeafQuery | ExistenceQuery;
+export type FetchableQuery = LeafQuery | ExistenceQuery<any>;
 export type StructuralQuery = LiteralQuery | KeysQuery | IdsQuery | PropertiesQuery;
 
 export type Query = StructuralQuery | FetchableQuery;
@@ -98,13 +103,17 @@ export type ResultProcessorMapping<
   [I in keyof Required<R>]: ResultProcessor<Required<R>[I], A, C>;
 };
 
-export type Resolver<R extends Result, C extends Context> = Handler<Reverse<C>, R>;
+export type Resolver<Q extends Query, R extends Result, C extends Context> = Handler<
+  Concat<Reverse<C>, [Q]>,
+  R
+>;
 
 export type ResolverConnector<
   A extends Resolvers,
+  Q extends Query,
   R extends Result,
   C extends Context
-> = (a: A) => Resolver<R, C>;
+> = (a: A) => Resolver<Q, R, C>;
 
 export type QueryProcessorMapping<
   A extends Resolvers,


### PR DESCRIPTION
Previously all queries where always represented by the literal value `true`. This PR adds support for arbitrary resolver parameters.